### PR TITLE
Feat/#3 suji

### DIFF
--- a/src/components/Reservation/DeleteAlert.jsx
+++ b/src/components/Reservation/DeleteAlert.jsx
@@ -1,0 +1,73 @@
+import { useProductActionContext } from '../../contexts/ProductContext';
+import { Button, IconButton } from '@chakra-ui/button';
+import { useDisclosure } from '@chakra-ui/hooks';
+import {
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialog,
+  AlertDialogOverlay,
+} from '@chakra-ui/modal';
+import { useRef } from 'react';
+import { BsTrash } from 'react-icons/bs';
+
+export default function DeleteAlert({ reservationItem }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef();
+  const { deleteProduct } = useProductActionContext();
+
+  const onClickHandler = () => {
+    deleteProduct(reservationItem);
+    window.location.reload();
+  };
+
+  return (
+    <>
+      <IconButton
+        aria-label='minusBtn'
+        onClick={onOpen}
+        icon={<BsTrash />}
+        position='absolute'
+        top={5}
+        right={6}
+        minW={10}
+        colorScheme='red'
+        textAlign='center'
+      />
+
+      <AlertDialog
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+        isCentered>
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize='lg' fontWeight='bold'>
+              예약 상품 삭제
+            </AlertDialogHeader>
+
+            <AlertDialogBody>
+              상품을 장바구니에서 삭제하시겠습니까?
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button ref={cancelRef} onClick={onClose}>
+                취소
+              </Button>
+              <Button
+                colorScheme='red'
+                onClick={() => {
+                  onClickHandler();
+                  onClose();
+                }}
+                ml={3}>
+                삭제
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/Reservation/ReservationItem.jsx
+++ b/src/components/Reservation/ReservationItem.jsx
@@ -1,0 +1,88 @@
+import { useProductActionContext } from '../../contexts/ProductContext';
+import { useProduct } from '../../hooks/useProduct';
+import LazyImage from './../common/LazyImage';
+import DeleteAlert from './DeleteAlert';
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  Stack,
+  Text,
+  IconButton,
+  Tag,
+  AspectRatio,
+  Button,
+  Spacer,
+} from '@chakra-ui/react';
+import React from 'react';
+import { AiOutlinePlus, AiOutlineMinus } from 'react-icons/ai';
+
+export default function ReservationItem({ reservationItem }) {
+  const { name, mainImage, maximumPurchases, price, spaceCategory, count } =
+    reservationItem;
+  const { increaseCount, decreaseCount } = useProductActionContext();
+
+  // FIX ME
+  const handleIncreaseCount = () => {
+    increaseCount(reservationItem);
+    window.location.reload();
+  };
+
+  const handleDecreaseCount = () => {
+    decreaseCount(reservationItem);
+    window.location.reload();
+  };
+  return (
+    <Card
+      direction={{ base: 'column', sm: 'row' }}
+      overflow='hidden'
+      variant='outline'
+      cursor='pointer'>
+      <AspectRatio width={{ base: '100%', sm: '200px' }} ratio={1}>
+        <LazyImage src={mainImage} alt={name} width='100%' />
+      </AspectRatio>
+
+      <Stack flex='1'>
+        <CardBody position='relative'>
+          <DeleteAlert reservationItem={reservationItem} />
+          <Text fontSize='md' noOfLines={1} pr={10}>
+            {name}
+          </Text>
+          <Text fontWeight='bold' fontSize='md' py='2'>
+            {price.toLocaleString()}원{' '}
+          </Text>
+          <Tag>{spaceCategory}</Tag>
+        </CardBody>
+
+        <CardFooter justifyContent='flex-end'>
+          <Text fontSize='sm' py='2'>
+            (최대 구매 가능 개수: {maximumPurchases}개)
+          </Text>
+          <Spacer />
+          <IconButton
+            onClick={handleDecreaseCount}
+            aria-label='minusBtn'
+            icon={<AiOutlineMinus />}
+          />
+          <Button colorScheme='whiteAlpha' color='black' cursor='default'>
+            {count}
+          </Button>
+          {count >= maximumPurchases ? (
+            <IconButton
+              cursor='no-drop'
+              aria-label='plusBtn'
+              icon={<AiOutlinePlus />}
+            />
+          ) : (
+            <IconButton
+              onClick={handleIncreaseCount}
+              colorScheme='linkedin'
+              aria-label='plusBtn'
+              icon={<AiOutlinePlus />}
+            />
+          )}
+        </CardFooter>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Reservation/ReservationList.jsx
+++ b/src/components/Reservation/ReservationList.jsx
@@ -1,0 +1,40 @@
+import { useProduct } from '../../hooks/useProduct';
+import ReservationItem from './ReservationItem';
+import ReservationSummary from './ReservationSummary';
+import { Divider, VStack, Center, Button, Heading } from '@chakra-ui/react';
+import React from 'react';
+import { useNavigate } from 'react-router';
+
+export default function ReservationList() {
+  const navigate = useNavigate();
+  const [storageList] = useProduct();
+
+  return (
+    <VStack
+      divider={<Divider borderColor='gray.200' />}
+      spacing={4}
+      align='stretch'
+      p={5}>
+      {storageList.length === 0 ? (
+        <Center flexDirection='column' gap='16px' height={700}>
+          <Heading size='lg'>예약된 상품이 없습니다.</Heading>
+          <br />
+          <Button colorScheme='linkedin' onClick={() => navigate('/')}>
+            상품 보러가기
+          </Button>
+        </Center>
+      ) : (
+        <>
+          <ReservationSummary reservationList={storageList} />
+          {storageList &&
+            storageList.map(reservationItem => (
+              <ReservationItem
+                key={reservationItem.idx}
+                reservationItem={reservationItem}
+              />
+            ))}
+        </>
+      )}
+    </VStack>
+  );
+}

--- a/src/components/Reservation/ReservationSummary.jsx
+++ b/src/components/Reservation/ReservationSummary.jsx
@@ -1,0 +1,20 @@
+import { Text, Card, CardFooter, Spacer } from '@chakra-ui/react';
+
+export default function ReservationSummary({ reservationList }) {
+  return (
+    <Card variant='outline'>
+      <CardFooter px='5' py='3'>
+        <Text fontWeight='semibold' fontSize='lg'>
+          총 합계 금액
+        </Text>
+        <Spacer />
+        <Text fontWeight='bold' fontSize='xl'>
+          {reservationList
+            .reduce((acc, cur) => acc + cur.price * cur.count, 0)
+            .toLocaleString()}
+          원
+        </Text>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/product/ProductDetail.jsx
+++ b/src/components/product/ProductDetail.jsx
@@ -17,6 +17,7 @@ import {
   IconButton,
   Text,
   AspectRatio,
+  useToast,
 } from '@chakra-ui/react';
 import React from 'react';
 import { RiShoppingBag2Fill } from 'react-icons/ri';
@@ -30,11 +31,31 @@ const ProductDetail = ({ isOpen, onClose, product }) => {
     maximumPurchases,
     description,
     registrationDate,
+    count,
   } = product;
   const { addProduct } = useProductActionContext();
+  const toast = useToast();
 
   const onClickHandler = () => {
     addProduct(product);
+    if (!count || count < maximumPurchases) {
+      toast({
+        title: '상품이 장바구니에 추가되었습니다!',
+        duration: 2000,
+        colorScheme: 'linkedin',
+        isClosable: true,
+      });
+    } else {
+      toast({
+        title: '장바구니 담기 실패!',
+        description: '최대 구매 가능 횟수를 초과하였습니다. ',
+        status: 'error',
+        duration: 2000,
+        colorScheme: 'linkedin',
+
+        isClosable: true,
+      });
+    }
   };
 
   return (

--- a/src/components/product/ProductItem.jsx
+++ b/src/components/product/ProductItem.jsx
@@ -11,19 +11,46 @@ import {
   Tag,
   useDisclosure,
   AspectRatio,
+  useToast,
 } from '@chakra-ui/react';
 import React from 'react';
 import { RiShoppingBag2Fill } from 'react-icons/ri';
 
 const ProductItem = ({ product }) => {
-  const { idx, name, mainImage, price, spaceCategory } = product;
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    idx,
+    name,
+    mainImage,
+    price,
+    spaceCategory,
+    count,
+    maximumPurchases,
+  } = product;
   const { addProduct } = useProductActionContext();
+  const toast = useToast();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const onClickHandler = e => {
     e.stopPropagation();
     addProduct(product);
+    if (!count || count < maximumPurchases) {
+      toast({
+        title: '상품이 장바구니에 추가되었습니다!',
+        duration: 2000,
+        colorScheme: 'linkedin',
+        isClosable: true,
+      });
+    } else {
+      toast({
+        title: '장바구니 담기 실패!',
+        description: '최대 구매 가능 횟수를 초과하였습니다. ',
+        status: 'error',
+        duration: 2000,
+        colorScheme: 'linkedin',
+
+        isClosable: true,
+      });
+    }
   };
 
   return (

--- a/src/contexts/ProductContext.jsx
+++ b/src/contexts/ProductContext.jsx
@@ -5,11 +5,15 @@ const ProductValueContext = createContext();
 const ProductActionContext = createContext();
 
 export const ProductProvider = ({ children }) => {
-  const [addedList, { addProduct, deleteProduct }] = useProduct([]);
+  const [
+    addedList,
+    { addProduct, deleteProduct, increaseCount, decreaseCount },
+  ] = useProduct([]);
 
   return (
     <ProductValueContext.Provider value={addedList}>
-      <ProductActionContext.Provider value={{ addProduct, deleteProduct }}>
+      <ProductActionContext.Provider
+        value={{ addProduct, deleteProduct, increaseCount, decreaseCount }}>
         {children}
       </ProductActionContext.Provider>
     </ProductValueContext.Provider>

--- a/src/hooks/useProduct.js
+++ b/src/hooks/useProduct.js
@@ -5,10 +5,28 @@ const productReducer = (products, action) => {
 
   switch (action.type) {
     case 'ADD':
-      const newProductList = [...products, newProduct];
+      const filteredList = products.filter(product => {
+        return product.idx === newProduct.idx;
+      });
+      let newProductList = [];
+      if (filteredList.length > 0) {
+        newProductList = products.map(product => {
+          if (
+            product.idx === newProduct.idx &&
+            product.count < product.maximumPurchases
+          ) {
+            product.count++;
+          }
+          return product;
+        });
+      } else {
+        newProduct.count = 1;
+        newProductList = [...products, newProduct];
+      }
       localStorage.setItem('products', JSON.stringify(newProductList));
 
       return newProductList;
+
     case 'DELETE':
       const deletedList = products.filter(
         item => item.idx !== targetProduct.idx
@@ -16,13 +34,41 @@ const productReducer = (products, action) => {
       localStorage.setItem('products', JSON.stringify(deletedList));
 
       return deletedList;
+
+    case 'INCREASE':
+      const increasedList = products.map(product => {
+        if (
+          product.idx === targetProduct.idx &&
+          product.count < product.maximumPurchases
+        ) {
+          return { ...product, count: (product.count += 1) };
+        }
+        return product;
+      });
+      localStorage.setItem('products', JSON.stringify(increasedList));
+
+      return increasedList;
+
+    case 'DECREASE':
+      const decreasedList = products.map(product => {
+        if (product.idx === targetProduct.idx && product.count > 0) {
+          return { ...product, count: (product.count -= 1) };
+        }
+        return product;
+      });
+      localStorage.setItem('products', JSON.stringify(decreasedList));
+
+      return decreasedList;
+
     default:
       throw Error(`${action.type} : 알 수 없는 액션 타입입니다.`);
   }
 };
 
 export const useProduct = () => {
-  const [response, dispatch] = useReducer(productReducer, []);
+  const storagedList = JSON.parse(localStorage.getItem('products')) ?? [];
+
+  const [response, dispatch] = useReducer(productReducer, [...storagedList]);
 
   const addProduct = newProduct => {
     dispatch({ type: 'ADD', newProduct });
@@ -32,5 +78,16 @@ export const useProduct = () => {
     dispatch({ type: 'DELETE', targetProduct });
   };
 
-  return [response, { addProduct, deleteProduct }];
+  const increaseCount = targetProduct => {
+    dispatch({ type: 'INCREASE', targetProduct });
+  };
+
+  const decreaseCount = targetProduct => {
+    dispatch({ type: 'DECREASE', targetProduct });
+  };
+
+  return [
+    response,
+    { addProduct, deleteProduct, increaseCount, decreaseCount },
+  ];
 };

--- a/src/pages/reservations/Reservation.jsx
+++ b/src/pages/reservations/Reservation.jsx
@@ -1,0 +1,21 @@
+import ReservationList from '../../components/Reservation/ReservationList';
+import Header from '../../components/common/Header';
+import { Container, Icon } from '@chakra-ui/react';
+import React from 'react';
+import { AiOutlineHome } from 'react-icons/ai';
+import { Link } from 'react-router-dom';
+
+export default function Reservation() {
+  const rightComp = () => (
+    <Link to='/main'>
+      <Icon as={AiOutlineHome} boxSize='6' />
+    </Link>
+  );
+
+  return (
+    <Container maxW='container.sm' backgroundColor='white'>
+      <Header rightComp={rightComp()} />
+      <ReservationList />
+    </Container>
+  );
+}

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -1,4 +1,5 @@
 import MainPage from '../pages/MainPage';
+import Reservation from '../pages/reservations/Reservation';
 import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
@@ -7,6 +8,7 @@ export default function router() {
     <Routes>
       <Route path='/' element={<Navigate to='/main' />} />
       <Route path='/main' element={<MainPage />} />
+      <Route path='/reservations' element={<Reservation />} />
     </Routes>
   );
 }


### PR DESCRIPTION
# 요구사항
* 여행 상품 장바구니 (/reservations)를 만들어주세요.
- [x] 저장한 여행 상품의 리스트를 보여주고 삭제가 가능할 수 있도록 구성해주세요.
- [x] 여행 상품의 구매 수량을 변경 가능할 수 있도록 해주세요.
- [x] 장바구니에 있는 여행 상품의 총 결제액 수를 계산하여 표시해주세요

## 구현사항
- 장바구니에서 예약상품 삭제를 눌렀을 때 alert창 띄운 후 삭제
- 최대 구매 가능 수량과 장바구니 구매 가능 수량이 같다면, plusIconBtn의 cursor `no-drop`으로 변경
- 최대 구매 가능 수량과 장바구니 구매 가능 수량이 같다면, 예약 불가 toast 띄우기
- /main에서 예약시, 장바구니 담기 성공 toast 띄우기

![요구사항3](https://user-images.githubusercontent.com/78632299/224218144-9bccb768-fcfe-40b3-9143-969a8c998d0c.gif)

## FIX ME 
- 실시간으로 ReservationList가 업데이트 되지만, 화면에 렌더되지 않아 `window.location.reload()`로 기재해뒀습니다. useEffect를 사용하여 렌더링를 맞추는 작업이 필요합니다. 

## 기타
- context + Reducer 활용해서 구현해보려고 했는데, 만날 수 있는 오류란 오류는 다 만난 것 같네요.. 주말동안 조금 더 공부해오겠습니다.. !
